### PR TITLE
feat: Add fallback to `Symbol.for(…)`

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,12 @@ var match = String.prototype.match;
 var bigIntValueOf = typeof BigInt === 'function' ? BigInt.prototype.valueOf : null;
 
 var inspectCustom = require('./util.inspect').custom;
+/* eslint-disable no-restricted-properties */
+if (!inspectCustom && typeof Symbol === 'function' && typeof Symbol['for'] === 'function') {
+    inspectCustom = Symbol['for']('nodejs.util.inspect.custom');
+}
+/* eslint-enable no-restricted-properties */
+
 var inspectSymbol = inspectCustom && isSymbol(inspectCustom) ? inspectCustom : null;
 
 module.exports = function inspect_(obj, options, depth, seen) {
@@ -142,6 +148,10 @@ module.exports = function inspect_(obj, options, depth, seen) {
     }
     return String(obj);
 };
+
+if (inspectSymbol) {
+    module.exports.custom = inspectSymbol;
+}
 
 function wrapQuotes(s, defaultStyle, opts) {
     var quoteChar = (opts.quoteStyle || defaultStyle) === 'double' ? '"' : "'";


### PR DESCRIPTION
**Node&nbsp;10.12** and&nbsp;newer&nbsp;registers [the&nbsp;`util.inspect.custom`&nbsp;symbol](https://nodejs.org/api/util.html#util_util_inspect_custom) as&nbsp;`nodejs.util.inspect.custom`, making&nbsp;it&nbsp;possible to&nbsp;use&nbsp;`Symbol.for('nodejs.util.inspect.custom')` to&nbsp;get&nbsp;the&nbsp;equivalent `util.inspect.custom`&nbsp;symbol without&nbsp;depending&nbsp;on&nbsp;`util`.