### PR TITLE
Optimize npm build

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,10 @@
     "email": "mail@substack.net",
     "url": "http://substack.net"
   },
+  "files": [
+    "index.js",
+    "util.inspect.js"
+  ],
   "funding": {
     "url": "https://github.com/sponsors/ljharb"
   },


### PR DESCRIPTION
We don't need to ship tests and other project specific files to users