### PR TITLE
[Tests] fix tests for node < 10, due to regex match `groups`

### DIFF
--- a/test/values.js
+++ b/test/values.js
@@ -168,6 +168,10 @@ test('RegExps', function (t) {
     t.equal(inspect(new RegExp('abc', 'i')), '/abc/i', 'new RegExp shows properly');
 
     var match = 'abc abc'.match(/[ab]+/);
+    if (!('groups' in match)) {
+        // for node < 10
+        match.groups = undefined;
+    }
     t.equal(inspect(match), '[ \'ab\', index: 0, input: \'abc abc\', groups: undefined ]', 'RegExp match object shows properly');
 
     t.end();


### PR DESCRIPTION
(I'm doing this as a PR so I can test the require-allow-edits action)