### PR TITLE
define inspectSymbol using standard from nodejs

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,8 +65,7 @@ function addNumericSeparator(num, str) {
     return $replace.call(str, sepRegex, '$&_');
 }
 
-var inspectCustom = require('./util.inspect').custom;
-var inspectSymbol = inspectCustom && isSymbol(inspectCustom) ? inspectCustom : null;
+var inspectSymbol = Symbol.for('nodejs.util.inspect.custom');
 
 module.exports = function inspect_(obj, options, depth, seen) {
     var opts = options || {};


### PR DESCRIPTION
Rather than relying on important the util module for enable custom inspectors (which would not work in browsers), define the symbol as indicated by NodeJS (`Symbol.for("nodejs.util.inspect.custom")`)