### PR TITLE
fix: passing options to custom inspect

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,8 +65,9 @@ function addNumericSeparator(num, str) {
     return $replace.call(str, sepRegex, '$&_');
 }
 
-var inspectCustom = require('./util.inspect').custom;
-var inspectSymbol = inspectCustom && isSymbol(inspectCustom) ? inspectCustom : null;
+var utilInspect = require('./util.inspect');
+var inspectCustom = utilInspect.custom;
+var inspectSymbol = isSymbol(inspectCustom) ? inspectCustom : null;
 
 module.exports = function inspect_(obj, options, depth, seen) {
     var opts = options || {};
@@ -193,8 +194,8 @@ module.exports = function inspect_(obj, options, depth, seen) {
         return '{ [' + String(obj) + '] ' + $join.call(parts, ', ') + ' }';
     }
     if (typeof obj === 'object' && customInspect) {
-        if (inspectSymbol && typeof obj[inspectSymbol] === 'function') {
-            return obj[inspectSymbol]();
+        if (inspectSymbol && typeof obj[inspectSymbol] === 'function' && utilInspect) {
+            return utilInspect(obj, { depth: maxDepth - depth });
         } else if (customInspect !== 'symbol' && typeof obj.inspect === 'function') {
             return obj.inspect();
         }

--- a/test/inspect.js
+++ b/test/inspect.js
@@ -100,3 +100,40 @@ test('maxStringLength', function (t) {
 
     t.end();
 });
+
+test('inspect options', { skip: !utilInspect.custom }, function (t) {
+    var obj = {};
+    obj[utilInspect.custom] = function () {
+        return JSON.stringify(arguments);
+    };
+    t.equal(
+        inspect(obj),
+        utilInspect(obj, { depth: 5 }),
+        'custom symbols will use node\'s inspect'
+    );
+    t.equal(
+        inspect(obj, { depth: 2 }),
+        utilInspect(obj, { depth: 2 }),
+        'a reduced depth will be passed to node\'s inspect'
+    );
+    t.equal(
+        inspect({ d1: obj }, { depth: 3 }),
+        '{ d1: ' + utilInspect(obj, { depth: 2 }) + ' }',
+        'deep objects will receive a reduced depth'
+    );
+    t.equal(
+        inspect({ d1: obj }, { depth: 1 }),
+        '{ d1: [Object] }',
+        'unlike nodejs inspect, customInspect will not be used once the depth is exceeded.'
+    );
+    t.end();
+});
+
+test('inspect URL', { skip: typeof URL === 'undefined' }, function (t) {
+    t.match(
+        inspect(new URL('https://nodejs.org')),
+        /nodejs\.org/, // Different environments stringify it differently
+        'url can be inspected'
+    );
+    t.end();
+});


### PR DESCRIPTION
Node internal objects (like URL) [expect options to be passed in to inspect call](https://github.com/nodejs/node/blob/810893f145dbba6bfc823afbc5958505378ba963/lib/internal/url.js#L664). Without these options inspecting some native objects will result in unexpected errors. I noticed this problem when inspecting a URL object:

```
node:internal/url:689
    if (opts.showHidden) {
             ^

TypeError: Cannot read properties of undefined (reading 'showHidden')
    at [nodejs.util.inspect.custom] (node:internal/url:689:14)
    at inspect_ (/inspect-js/object-inspect/index.js:197:38)
    at Test.<anonymous> (/inspect-js/object-inspect/test/inspect.js:110:9)
    at Test.bound [as _cb] (/inspect-js/object-inspect/node_modules/tape/lib/test.js:99:32)
    at Test.run (/inspect-js/object-inspect/node_modules/tape/lib/test.js:117:31)
    at Test.bound [as run] (/inspect-js/object-inspect/node_modules/tape/lib/test.js:99:32)
    at Immediate.next (/inspect-js/object-inspect/node_modules/tape/lib/results.js:88:19)
    at process.processImmediate (node:internal/timers:471:21)
```

This PR fixes this by also passing inspect options to inspect calls.