### PR TITLE
Don't throw when `global` is not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -244,7 +244,10 @@ module.exports = function inspect_(obj, options, depth, seen) {
     if (typeof window !== 'undefined' && obj === window) {
         return '{ [object Window] }';
     }
-    if (obj === global) {
+    if (
+        (typeof globalThis !== 'undefined' && obj === globalThis)
+        || (typeof global !== 'undefined' && obj === global)
+    ) {
         return '{ [object globalThis] }';
     }
     if (!isDate(obj) && !isRegExp(obj)) {


### PR DESCRIPTION
`global` is not defined in some environments such as CF Workers and Vercel Edge Functions. Be defensive against that.