### PR TITLE
allow require('util') to throw

### DIFF
--- a/util.inspect.js
+++ b/util.inspect.js
@@ -1,5 +1,6 @@
 try {
-  module.exports = require('util').inspect;
+    // eslint-disable-next-line global-require
+    module.exports = require('util').inspect;
 } catch (_) {
-  module.exports = {};
+    module.exports = {};
 }

--- a/util.inspect.js
+++ b/util.inspect.js
@@ -1,1 +1,5 @@
-module.exports = require('util').inspect;
+try {
+  module.exports = require('util').inspect;
+} catch (_) {
+  module.exports = {};
+}


### PR DESCRIPTION
adds support for cjs environments with no node core modules and no bundler-style `browser` resolution