### PR TITLE
Add .js extension to require

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ function addNumericSeparator(num, str) {
     return $replace.call(str, sepRegex, '$&_');
 }
 
-var utilInspect = require('./util.inspect');
+var utilInspect = require('./util.inspect.js');
 var inspectCustom = utilInspect.custom;
 var inspectSymbol = isSymbol(inspectCustom) ? inspectCustom : null;
 


### PR DESCRIPTION
This fixes an issue with vite where it is strict about the file extension existing.