### PR TITLE
[Fix] guard `toStringTag` with correct ternary precedence

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,13 @@ var gOPS = Object.getOwnPropertySymbols;
 var symToString = typeof Symbol === 'function' && typeof Symbol.iterator === 'symbol' ? Symbol.prototype.toString : null;
 var hasShammedSymbols = typeof Symbol === 'function' && typeof Symbol.iterator === 'object';
 // ie, `has-tostringtag/shams
-var toStringTag = typeof Symbol === 'function' && Symbol.toStringTag && (typeof Symbol.toStringTag === hasShammedSymbols ? 'object' : 'symbol')
+var toStringTag = typeof Symbol === 'function'
+    && Symbol.toStringTag
+    && (
+        hasShammedSymbols
+            ? typeof Symbol.toStringTag === 'object'
+            : typeof Symbol.toStringTag === 'symbol'
+    )
     ? Symbol.toStringTag
     : null;
 var isEnumerable = Object.prototype.propertyIsEnumerable;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "sideEffects": false,
   "devDependencies": {
-    "@ljharb/eslint-config": "^22.2.0",
+    "@ljharb/eslint-config": "^22.2.3",
     "@pkgjs/support": "^0.0.6",
     "auto-changelog": "^2.5.0",
     "core-js": "^2.6.12",

--- a/test/toStringTag-precedence.js
+++ b/test/toStringTag-precedence.js
@@ -1,0 +1,50 @@
+'use strict';
+
+var test = require('tape');
+var mockProperty = require('mock-property');
+
+/*
+ * Regression test for a ternary-precedence bug where the guard
+ *   typeof Symbol.toStringTag === hasShammedSymbols ? 'object' : 'symbol'
+ * collapsed to a constant-truthy `'symbol'` (because `typeof x` is a string
+ * and `hasShammedSymbols` is a boolean), so a truthy-but-wrong-type
+ * `Symbol.toStringTag` (e.g. a string on a broken polyfill) was accepted as
+ * a valid toStringTag. The fix parenthesizes the inner ternary so the
+ * `typeof` is compared against the expected string.
+ */
+
+function FakeSymbol() {}
+FakeSymbol.toStringTag = 'tag'; // truthy, but `typeof` is 'string', not 'symbol'
+FakeSymbol.iterator = function () {}; // keep hasShammedSymbols false
+
+function C() {}
+C.prototype[FakeSymbol.toStringTag] = 'Oops';
+
+test('toStringTag precedence', function (t) {
+    t.plan(1);
+
+    var inspectPath = require.resolve('../');
+    var utilInspectPath = require.resolve('../util.inspect');
+
+    var restoreSymbol = mockProperty(global, 'Symbol', { value: FakeSymbol });
+    delete require.cache[inspectPath];
+    delete require.cache[utilInspectPath];
+    t.teardown(function () {
+        restoreSymbol();
+        delete require.cache[inspectPath];
+        delete require.cache[utilInspectPath];
+    });
+
+    var freshInspect = require('../'); // eslint-disable-line global-require
+
+    /*
+     * With the bug, `toStringTag` inside the module would be the string
+     * `'tag'`, and `'tag' in new C()` is true via the prototype chain,
+     * so inspect would splice a bogus `[Object]` tag into its output.
+     */
+    t.equal(
+        freshInspect(new C()),
+        'C {}',
+        'non-symbol `Symbol.toStringTag` is rejected and does not leak into output'
+    );
+});


### PR DESCRIPTION
The inner ternary `typeof Symbol.toStringTag === hasShammedSymbols ? 'object' : 'symbol'` compared `typeof` (a string) against `hasShammedSymbols` (a boolean), so it was always `false` and the expression was a constant truthy `'symbol'`. This defeated the sham-vs-native type validation; in a malformed Symbol sham where `Symbol.toStringTag` exists with the wrong type, downstream `toStringTag in obj` usage could misbehave.