### PR TITLE
[spam]

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://github.com/inspect-js/object-inspect.git"
+    "url": "git+https://github.com/inspect-js/object-inspect.git"
   },
   "homepage": "https://github.com/inspect-js/object-inspect",
   "keywords": [


### PR DESCRIPTION
Updates the package repository URL from an SSH URL to the canonical git+https form. This is a metadata-only change.